### PR TITLE
Updated max wager for double jeopardy daily double

### DIFF
--- a/jparty/game.py
+++ b/jparty/game.py
@@ -477,8 +477,11 @@ class Game(QObject):
     def get_dd_wager(self, player):
         self.answering_player = player
         self.soliciting_player = False
-
-        max_wager = max(self.answering_player.score, 1000)
+        if self.current_round is self.data.rounds[0]:
+            max_wager = max(self.answering_player.score, 1000)
+        else:
+            max_wager = max(self.answering_player.score, 2000)
+            
         wager_res = QInputDialog.getInt(
             self.host_display,
             "Wager",


### PR DESCRIPTION
Updated max to $2000 (if the player has less than $2000)

Originally in double jeopardy the max wager when a player has less than $2000 was only set to $2000. Now it knows that it is the second round and changes the max to $2000.