### PR TITLE
Display images pulled from J-Archive

### DIFF
--- a/jparty/game.py
+++ b/jparty/game.py
@@ -121,9 +121,11 @@ class Question:
     text: str
     answer: str
     category: str
+    image_link: str = None
     value: int = -1
     dd: bool = False
     complete: bool = False
+    
 
 
 class Board(object):

--- a/jparty/question_widget.py
+++ b/jparty/question_widget.py
@@ -3,7 +3,10 @@ from PyQt6.QtGui import (
     QPen,
     QColor,
     QFont,
+    QPixmap,
 )
+import requests
+import logging
 from PyQt6.QtWidgets import QWidget, QVBoxLayout
 
 from jparty.style import MyLabel, CARDPAL
@@ -16,10 +19,23 @@ class QuestionWidget(QWidget):
         self.setAutoFillBackground(True)
 
         self.main_layout = QVBoxLayout()
-        self.question_label = MyLabel(question.text.upper(), self.startFontSize, self)
 
+        # Question text
+        self.question_label = MyLabel(question.text.upper(), self.startFontSize, self)
         self.question_label.setFont(QFont("ITC_ Korinna"))
         self.main_layout.addWidget(self.question_label)
+
+        if question.image_link is not None:
+            logging.info(f"question has image: {question.image_link}")
+            self.image = QPixmap()
+            try:
+                request = requests.get(question.image_link)
+                self.image.loadFromData(request.content)
+                self.image = self.image.scaledToWidth(self.width() * 12)
+                self.question_label.setPixmap(self.image)
+            except requests.exceptions.RequestException as e:
+                logging.info(f"failed to load image: {question.image_link}")
+
         self.setLayout(self.main_layout)
 
         self.setPalette(CARDPAL)

--- a/jparty/question_widget.py
+++ b/jparty/question_widget.py
@@ -30,9 +30,10 @@ class QuestionWidget(QWidget):
             self.image = QPixmap()
             try:
                 request = requests.get(question.image_link)
-                self.image.loadFromData(request.content)
-                self.image = self.image.scaledToWidth(self.width() * 12)
-                self.question_label.setPixmap(self.image)
+                if b"Not Found" not in request.content:
+                    self.image.loadFromData(request.content)
+                    self.image = self.image.scaledToWidth(self.width() * 12)
+                    self.question_label.setPixmap(self.image)
             except requests.exceptions.RequestException as e:
                 logging.info(f"failed to load image: {question.image_link}")
 

--- a/jparty/retrieve.py
+++ b/jparty/retrieve.py
@@ -25,7 +25,7 @@ def list_to_game(s):
                 answer = s[row + n1 + 6][col + 1]
                 value = int(s[row + n1][0])
                 dd = address in s[n1 - 1][-1]
-                questions.append(Question(index, text, answer, cat, value, dd))
+                questions.append(Question(index, text, answer, cat, None, value, dd)) # TODO: Allow images
 
         boards.append(Board(categories, questions, dj=(n1 == 14)))
 
@@ -111,7 +111,7 @@ def get_JArchive_Game(game_id, wayback_url=None):
             value = MONIES[i][index[1]]
             answer = findanswer(clue)
             questions.append(
-                Question(index, text, answer, categories[index[0]], value, dd)
+                Question(index, text, answer, categories[index[0]], image_link, value, dd)
             )
         boards.append(Board(categories, questions, dj=(i == 1)))
 

--- a/jparty/retrieve.py
+++ b/jparty/retrieve.py
@@ -90,6 +90,18 @@ def get_JArchive_Game(game_id, wayback_url=None):
                 return None
 
             text = text_obj.text
+
+            # Extract image link
+            text_to_re = str(text_obj)
+            image_link_pattern = r'(\bhttps:\/\/www\.j-archive\.com\b[^"]*)'
+            image_link = re.findall(image_link_pattern, text_to_re)
+            if image_link:
+                image_link = image_link[0]  # Take the first link if there are multiple
+                logging.info(f"Question with image: {text_obj}, image_link: {image_link}")
+            else:
+                image_link = None
+                logging.info(f"Question: {text_obj}, image_link: {image_link}")
+
             index_key = text_obj["id"]
             index = (
                 int(index_key[-3]) - 1,


### PR DESCRIPTION
Display images pulled from J-Archive. If image fails to load, it falls back to regular text clue.

TODO in the future: Add a settings option to display **both text and image** for questions which have an image.