### PR TITLE
Add setting to control early buzz timeout

### DIFF
--- a/jparty/constants.py
+++ b/jparty/constants.py
@@ -3,7 +3,12 @@ QUESTIONTIME = 4
 MONIES = [[200, 400, 600, 800, 1000], [400, 800, 1200, 1600, 2000]]
 MAXPLAYERS = 8
 PORT = 8080
-EARLY_TIMEOUT_MS = 200
 BEFORE_REVEAL_WAIT_TIME = 1
 CATEGORY_REVEAL_TIME = 2
 QUESTION_REVEAL_TIME = 0.4
+
+DEFAULT_CONFIG = {
+  'theme': 'Default',
+  'showtextwithimages': 'False',
+  'earlybuzztimeout': 200
+}

--- a/jparty/game.py
+++ b/jparty/game.py
@@ -10,9 +10,10 @@ import sys
 import simpleaudio as sa
 from collections.abc import Iterable
 import logging
+import json
 
 from jparty.utils import SongPlayer, resource_path, CompoundObject
-from jparty.constants import FJTIME, QUESTIONTIME, EARLY_TIMEOUT_MS
+from jparty.constants import FJTIME, QUESTIONTIME
 
 
 class QuestionTimer(object):
@@ -177,6 +178,9 @@ class Game(QObject):
     def __init__(self):
         super().__init__()
 
+        with open('config.json', 'r') as f:
+            self.config = json.load(f)
+
         self.host_display = None
         self.main_display = None
         self.dc = None
@@ -270,6 +274,9 @@ class Game(QObject):
         self.dc.board_widget.load_round(self.current_round)
         self.buzzer_controller.accepting_players = False
         self.song_player.stop()
+        # Update config when game starts in case host made some settings changes
+        with open('config.json', 'r') as f:
+            self.config = json.load(f)
 
     def setDisplays(self, host_display, main_display):
         self.host_display = host_display

--- a/jparty/scoreboard.py
+++ b/jparty/scoreboard.py
@@ -9,7 +9,7 @@ from functools import partial
 
 from jparty.style import MyLabel
 from jparty.utils import resource_path
-from jparty.constants import EARLY_TIMEOUT_MS
+from jparty.constants import DEFAULT_CONFIG
 
 
 class NameLabel(MyLabel):
@@ -153,7 +153,7 @@ class PlayerWidget(QWidget):
     def __timeout_lights(self):
         self.background = self.timeout_background
         self.update()
-        time.sleep(EARLY_TIMEOUT_MS / 1000)
+        time.sleep(self.game.config.get('earlybuzztimeout', DEFAULT_CONFIG['earlybuzztimeout']) / 1000)
         self.player.istimedout = False
         self.set_lights(False)
         self.update()

--- a/jparty/welcome_widget.py
+++ b/jparty/welcome_widget.py
@@ -34,6 +34,7 @@ from jparty.retrieve import get_game, get_random_game
 from jparty.utils import resource_path, add_shadow, DynamicLabel, DynamicButton
 from jparty.helpmsg import helpmsg
 from jparty.style import WINDOWPAL
+from jparty.constants import DEFAULT_CONFIG
 
 
 class Image(qrcode.image.base.BaseImage):
@@ -334,23 +335,25 @@ class SettingsMenu(QDialog):
         with open('config.json', 'r') as f:
             config = json.load(f)
 
-        current_theme = config.get('theme', 'default')
-        current_showtextwithimages = config.get('showtextwithimages', 'false')
+        current_theme = config.get('theme', DEFAULT_CONFIG['theme'])
+        current_showtextwithimages = config.get('showtextwithimages', DEFAULT_CONFIG['showtextwithimages'])
+        current_earlybuzztimeout = config.get('earlybuzztimeout', DEFAULT_CONFIG['earlybuzztimeout'])
 
         self.setWindowTitle("Settings")
         self.setFixedSize(400, 200)
         layout = QVBoxLayout()
 
+        # Add info about theme change auto-restarting the game
+        settings_info = QLabel("Theme change auto-restarts the game.", self)
+        settings_info.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        settings_info.setFixedWidth(self.width())
+        palette = settings_info.palette()
+        palette.setColor(QPalette.ColorRole.WindowText, QColor(128, 128, 128))
+        settings_info.setPalette(palette)
+        settings_info_layout = QHBoxLayout()
+
         # Add a label for the "Theme" section
         theme_label = QLabel("Theme:", self)
-
-        # Add info about theme change auto-restarting the game
-        theme_info = QLabel("Theme change auto-restarts the game.", self)
-        theme_info.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        theme_info.setFixedWidth(self.width())
-        palette = theme_info.palette()
-        palette.setColor(QPalette.ColorRole.WindowText, QColor(128, 128, 128))
-        theme_info.setPalette(palette)
 
         # Add a combo box for theme selection
         self.theme_combobox = QComboBox(self)
@@ -400,9 +403,35 @@ class SettingsMenu(QDialog):
         showtextwithimages_layout.addWidget(showtextwithimages_label)
         showtextwithimages_layout.addWidget(self.showtextwithimages_combobox)
 
-        # Add the horizontal layout to the main layout
+        # Add a label for the "earlybuzztimeout" section
+        earlybuzztimeout_label = QLabel("Early buzz timeout (ms):", self)
+
+        # Add a combo box for earlybuzztimeout selection
+        self.earlybuzztimeout_combobox = QLineEdit(self)
+        self.earlybuzztimeout_combobox.setText(str(current_earlybuzztimeout))
+
+        # Set the font to bold and text color to white
+        font = self.earlybuzztimeout_combobox.font()
+        font.setBold(True)
+        self.earlybuzztimeout_combobox.setFont(font)
+        palette = self.earlybuzztimeout_combobox.palette()
+        palette.setColor(QPalette.ColorRole.WindowText, QColor(255, 255, 255))
+        self.earlybuzztimeout_combobox.setPalette(palette)
+
+        # Add a white border around the dropdown menu
+        self.earlybuzztimeout_combobox.setStyleSheet("QComboBox { border: 2px solid white; }")
+
+        # Create a horizontal layout for the label and combo box
+        earlybuzztimeout_layout = QHBoxLayout()
+        earlybuzztimeout_layout.addWidget(earlybuzztimeout_label)
+        earlybuzztimeout_layout.addWidget(self.earlybuzztimeout_combobox)
+
+        # Add the horizontal layouts to the main layout
+        layout.addLayout(settings_info_layout)
+        layout.addSpacing(20)
         layout.addLayout(theme_layout)
         layout.addLayout(showtextwithimages_layout)
+        layout.addLayout(earlybuzztimeout_layout)
 
         # Add space before the Apply button
         layout.addSpacing(10)
@@ -446,12 +475,16 @@ class SettingsMenu(QDialog):
         # Show text with images setting
         showtextwithimages = self.showtextwithimages_combobox.currentText()
 
+        # Early buzz timeout setting
+        earlybuzztimeout = int(self.earlybuzztimeout_combobox.text())
+
         # Save config
         logging.info("Saving settings...")
         with open('config.json', 'w') as f:
             json.dump({
                 'theme': theme,
                 'showtextwithimages': showtextwithimages,
+                'earlybuzztimeout': earlybuzztimeout
             }, f)
 
         if requires_restart:

--- a/run.py
+++ b/run.py
@@ -4,15 +4,13 @@ import os
 import json
 import subprocess
 import signal
+from jparty.constants import DEFAULT_CONFIG
 
 # Check if config.json exists
 if not os.path.exists('config.json'):
     # If not, create it with a default settings
     with open('config.json', 'w') as f:
-        data = {
-            'theme': 'default',
-            'showtextwithimages': 'false'
-        }
+        data = DEFAULT_CONFIG
         json.dump(data, f)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Added a setting to control the timeout penalty for buzzing in early.

Also cleaned up some of the code for getting/setting config.json

<img width="362" alt="python_a4OaQSfnAV" src="https://github.com/gdsimco/JParty-with-buzzers/assets/79669334/8b6933b1-2478-42b0-9bab-e9ff4a76c1a1">