### PR TITLE
Fixed theme change causing a crash. (urgent merge)

### DIFF
--- a/jparty/welcome_widget.py
+++ b/jparty/welcome_widget.py
@@ -469,7 +469,6 @@ class SettingsMenu(QDialog):
         old_theme = config.get('theme', 'default')
         theme = self.theme_combobox.currentText()
         if theme != old_theme:
-            self.change_theme(theme)
             requires_restart = True
 
         # Show text with images setting


### PR DESCRIPTION
Fixed bug where game would crash when changing theme. This is because it was still calling self.change_theme(theme) which is a method that does not exist anymore.