### PR TITLE
Preload images in the background

### DIFF
--- a/jparty/question_widget.py
+++ b/jparty/question_widget.py
@@ -32,25 +32,27 @@ class QuestionWidget(QWidget):
 
         if question.image_link is not None:
             logging.info(f"question has image: {question.image_link}")
-            self.image = QPixmap()
-            try:
-                request = requests.get(question.image_link)
-                if b"Not Found" not in request.content:
-                    self.image.loadFromData(request.content)
-                    
-                    if self.config.get('showtextwithimages', 'False') == 'True':
-                        self.image = self.image.scaledToHeight(self.height() * 12)
+            if question.image_content is None:
+                try:
+                    request = requests.get(question.image_link)
+                    question.image_content = request.content
+                except requests.exceptions.RequestException as e:
+                    logging.info(f"failed to load image: {question.image_link}")
+            
+            if question.image_content is not None and b"Not Found" not in question.image_content:
+                self.image = QPixmap()
+                self.image.loadFromData(question.image_content)
+                
+                if self.config.get('showtextwithimages', 'False') == 'True':
+                    self.image = self.image.scaledToHeight(self.height() * 12)
 
-                        # Create a QLabel for the image
-                        self.image_label = MyLabel("", self.startFontSize, self)
-                        self.image_label.setPixmap(self.image)
-                        self.main_layout.addWidget(self.image_label)
-                    else:
-                        self.image = self.image.scaledToWidth(self.width() * 12)
-                        self.question_label.setPixmap(self.image)
-
-            except requests.exceptions.RequestException as e:
-                logging.info(f"failed to load image: {question.image_link}")
+                    # Create a QLabel for the image
+                    self.image_label = MyLabel("", self.startFontSize, self)
+                    self.image_label.setPixmap(self.image)
+                    self.main_layout.addWidget(self.image_label)
+                else:
+                    self.image = self.image.scaledToWidth(self.width() * 12)
+                    self.question_label.setPixmap(self.image)
 
         self.setLayout(self.main_layout)
 

--- a/jparty/retrieve.py
+++ b/jparty/retrieve.py
@@ -41,7 +41,7 @@ def list_to_game(s):
                 text_extract_pattern = r'https?:\/\/\S+?\.(?:png|jpe?g|gif|bmp)\b'
                 text = re.sub(text_extract_pattern, '', text)
 
-                questions.append(Question(index, text, answer, cat, image_link, value, dd))
+                questions.append(Question(index, text, answer, cat, image_link, None, value, dd))
 
         boards.append(Board(categories, questions, dj=(n1 == 14)))
 
@@ -127,7 +127,7 @@ def get_JArchive_Game(game_id, wayback_url=None):
             value = MONIES[i][index[1]]
             answer = findanswer(clue)
             questions.append(
-                Question(index, text, answer, categories[index[0]], image_link, value, dd)
+                Question(index, text, answer, categories[index[0]], image_link, None, value, dd)
             )
         boards.append(Board(categories, questions, dj=(i == 1)))
 

--- a/jparty/retrieve.py
+++ b/jparty/retrieve.py
@@ -25,21 +25,11 @@ def list_to_game(s):
                 answer = s[row + n1 + 6][col + 1]
                 value = int(s[row + n1][0])
                 dd = address in s[n1 - 1][-1]
-                # Getting the image link:
-                image_link = None
-                # Extract image link
-                image_link_pattern = r'\bhttps?:\/\/\S+?\.(?:png|jpe?g|bmp)\b'
-                image_link = re.findall(image_link_pattern, text)
-                if image_link:
-                    image_link = image_link[0]  # Take the first link if there are multiple
-                    logging.info(f"Question with image: {text}, image_link: {image_link}")
-                else:
-                    image_link = None
-                    logging.info(f"Question: {text}, image_link: {image_link}")
-
-                # Remove image link from text:
-                text_extract_pattern = r'https?:\/\/\S+?\.(?:png|jpe?g|gif|bmp)\b'
-                text = re.sub(text_extract_pattern, '', text)
+                
+                # Extract image link from text
+                process_values = get_image_link(text)
+                text = process_values['text']
+                image_link = process_values['image_link']
 
                 questions.append(Question(index, text, answer, cat, image_link, None, value, dd))
 
@@ -49,14 +39,42 @@ def list_to_game(s):
     fj = s[-1]
     index = (0, 0)
     text = fj[2]
+    
+    # Extract image link from text
+    process_values = get_image_link(text)
+    text = process_values['text']
+    image_link = process_values['image_link']
+
     answer = fj[3]
     category = fj[1]
-    question = Question(index, text, answer, category)
+    question = Question(index, text, answer, category, image_link)
     boards.append(FinalBoard(category, question))
     date = fj[5]
     comments = fj[7]
     return GameData(boards, date, comments)
 
+def get_image_link(text):
+    # Getting the image link:
+    image_link = None
+    # Extract image link
+    image_link_pattern = r'\bhttps?:\/\/\S+?\.(?:png|jpe?g|bmp)\b'
+    image_link = re.findall(image_link_pattern, text)
+    if image_link:
+        image_link = image_link[0]  # Take the first link if there are multiple
+        logging.info(f"Question with image: {text}, image_link: {image_link}")
+    else:
+        image_link = None
+        logging.info(f"Question: {text}, image_link: {image_link}")
+
+    # Remove image link from text:
+    text_extract_pattern = r'https?:\/\/\S+?\.(?:png|jpe?g|gif|bmp)\b'
+    text = re.sub(text_extract_pattern, '', text)
+
+    return_values = {
+        'text': text,
+        'image_link': image_link
+    }
+    return return_values
 
 def get_Gsheet_game(file_id):
     csv_url = f"https://docs.google.com/spreadsheet/ccc?key={file_id}&output=csv"


### PR DESCRIPTION
Preload images in the background at the start of each round. There is a delay of 2 seconds between loading each image in the background to prevent rate limit errors from the website we are fetching them from.

If an image is not already preloaded when you pull up the question then it will load on the spot like before.

Also fixed a bug where the space for the image was empty when the image failed to load. Now it will just show the question full screen like normal if an image fails to load.