### PR TITLE
Fix image loading and formatting bugs

### DIFF
--- a/jparty/game.py
+++ b/jparty/game.py
@@ -412,7 +412,13 @@ class Game(QObject):
             logging.info(f"pre-loading image: {question.image_link}")
             request = requests.get(question.image_link, timeout=1)
             question.image_content = request.content
+            logging.info(f"loaded image: {question.image_link}")
 
+        except requests.Timeout:
+            # Some websites always timeout and load forever, maybe because it detects that it's a bot
+            # Set the image content to "Not Found" to avoid trying to load it again
+            logging.info(f"timed out loading image: {question.image_link}")
+            question.image_content = b"Not Found"
         except requests.exceptions.RequestException as e:
             logging.info(f"failed to load image: {question.image_link}")
 

--- a/jparty/game.py
+++ b/jparty/game.py
@@ -410,7 +410,7 @@ class Game(QObject):
     def load_image(self, question):
         try:
             logging.info(f"pre-loading image: {question.image_link}")
-            request = requests.get(question.image_link)
+            request = requests.get(question.image_link, timeout=1)
             question.image_content = request.content
 
         except requests.exceptions.RequestException as e:

--- a/jparty/game.py
+++ b/jparty/game.py
@@ -411,8 +411,6 @@ class Game(QObject):
         try:
             logging.info(f"pre-loading image: {question.image_link}")
             request = requests.get(question.image_link)
-            if b"Not Found" not in request.content:
-                logging.info(f"pre-loading image SUCCESSFUL: {request.content}")
             question.image_content = request.content
 
         except requests.exceptions.RequestException as e:

--- a/jparty/question_widget.py
+++ b/jparty/question_widget.py
@@ -91,6 +91,8 @@ class DailyDoubleWidget(QuestionWidget):
     def __init__(self, question, parent=None):
         super().__init__(question, parent)
         self.question_label.setVisible(False)
+        if hasattr(self, 'image_label'):
+            self.image_label.setVisible(False)
 
         self.dd_label = MyLabel("DAILY<br/>DOUBLE!", self.startDDFontSize, self)
         self.main_layout.replaceWidget(self.question_label, self.dd_label)
@@ -103,6 +105,8 @@ class DailyDoubleWidget(QuestionWidget):
         self.dd_label.deleteLater()
         self.dd_label = None
         self.question_label.setVisible(True)
+        if hasattr(self, 'image_label'):
+            self.image_label.setVisible(True)
 
 
 class HostDailyDoubleWidget(HostQuestionWidget, DailyDoubleWidget):

--- a/jparty/question_widget.py
+++ b/jparty/question_widget.py
@@ -37,6 +37,7 @@ class QuestionWidget(QWidget):
                 try:
                     request = requests.get(question.image_link, timeout=1)
                     question.image_content = request.content
+                    logging.info(f"loaded image: {question.image_link}")
                 except requests.exceptions.RequestException as e:
                     logging.info(f"failed to load image: {question.image_link}")
             

--- a/jparty/question_widget.py
+++ b/jparty/question_widget.py
@@ -35,7 +35,7 @@ class QuestionWidget(QWidget):
             logging.info(f"question has image: {question.image_link}")
             if question.image_content is None:
                 try:
-                    request = requests.get(question.image_link)
+                    request = requests.get(question.image_link, timeout=1)
                     question.image_content = request.content
                 except requests.exceptions.RequestException as e:
                     logging.info(f"failed to load image: {question.image_link}")

--- a/jparty/retrieve.py
+++ b/jparty/retrieve.py
@@ -57,7 +57,7 @@ def get_image_link(text):
     # Getting the image link:
     image_link = None
     # Extract image link
-    image_link_pattern = r'\bhttps?:\/\/\S+?\.(?:png|jpe?g|bmp)\b'
+    image_link_pattern = r'\bhttps?:\/\/\S+?\.(?:png|jpe?g|bmp|PNG|JPE?G|BMP)\b'
     image_link = re.findall(image_link_pattern, text)
     if image_link:
         image_link = image_link[0]  # Take the first link if there are multiple
@@ -67,7 +67,7 @@ def get_image_link(text):
         logging.info(f"Question: {text}, image_link: {image_link}")
 
     # Remove image link from text:
-    text_extract_pattern = r'https?:\/\/\S+?\.(?:png|jpe?g|gif|bmp)\b'
+    text_extract_pattern = r'https?:\/\/\S+?\.(?:png|jpe?g|gif|bmp|PNG|JPE?G|BMP)\b'
     text = re.sub(text_extract_pattern, '', text)
 
     return_values = {


### PR DESCRIPTION
Fixed some bugs with images:

- Image no longer cuts off text for the "Daily Double" title screen.
- Images with capital extensions will work too now.
- Set timeout for requesting images. Some websites make us wait indefinitely possibly because it detects traffic is coming from a bot.
- Don't try requesting a timed out image again. It never works the second time and it will just make the game freeze for a second.