### PR TITLE
Show each player's buzz delays to the host

### DIFF
--- a/jparty/scoreboard.py
+++ b/jparty/scoreboard.py
@@ -8,7 +8,7 @@ from base64 import urlsafe_b64decode
 from functools import partial
 
 from jparty.style import MyLabel
-from jparty.utils import resource_path
+from jparty.utils import resource_path, add_shadow
 from jparty.constants import DEFAULT_CONFIG
 
 
@@ -56,9 +56,20 @@ class PlayerWidget(QWidget):
         self.__flash_thread = None
         self.__light_thread = None
         self.__timeout_thread = None
+        self.buzz_time = None # Keeps track of datetime when player buzzed in early
+        self.buzz_delay = None # Holds stats for buzz delay
 
         self.name_label = NameLabel(player.name, self)
         self.score_label = MyLabel("$0", self.startScoreFontSize, self)
+        self.stats_label = MyLabel("Stats", self.height() * 0.8, self)
+        self.dummy_stats_label = MyLabel("", self.height() * 0.8, self)
+
+        if self.parent().parent().parent().host():
+            self.dummy_stats_label.setVisible(False)
+        else:
+            self.stats_label.setVisible(False)
+
+        add_shadow(self.stats_label, 10, 0)
 
         # self.resizeEvent(None)
         self.update_score()
@@ -76,11 +87,14 @@ class PlayerWidget(QWidget):
         self.highlighted = False
 
         layout = QVBoxLayout()
-        layout.addStretch(4)
+        layout.addStretch(5)
         layout.addWidget(self.score_label, 10)
-        layout.addStretch(11)
-        layout.addWidget(self.name_label, 31)
-        layout.addStretch(10)
+        layout.addStretch(22)
+        layout.addWidget(self.name_label, 46)
+        layout.addStretch(2)
+        layout.addWidget(self.stats_label, 10)
+        layout.addWidget(self.dummy_stats_label, 10)
+        layout.addStretch(2)
 
         self.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Expanding)
         self.setLayout(layout)
@@ -124,6 +138,19 @@ class PlayerWidget(QWidget):
         self.score_label.setPalette(palette)
 
         self.score_label.setText(f"{score:,}")
+
+    def update_stats(self, delay, early=False):
+        if self.buzz_delay is not None:
+            return
+        self.buzz_delay = delay
+        if early:
+            self.stats_label.setText('{0:.2f}s early'.format(self.buzz_delay))
+        else:
+            self.stats_label.setText('{0:.2f}s late'.format(self.buzz_delay))
+    
+    def clear_stats(self):
+        self.buzz_delay = None
+        self.stats_label.setText('')
 
     def run_lights(self):
         self.__light_thread = Thread(target=self.__lights, name="lights")

--- a/jparty/scoreboard.py
+++ b/jparty/scoreboard.py
@@ -61,7 +61,7 @@ class PlayerWidget(QWidget):
 
         self.name_label = NameLabel(player.name, self)
         self.score_label = MyLabel("$0", self.startScoreFontSize, self)
-        self.stats_label = MyLabel("Stats", self.height() * 0.8, self)
+        self.stats_label = MyLabel("", self.height() * 0.8, self)
         self.dummy_stats_label = MyLabel("", self.height() * 0.8, self)
 
         if self.parent().parent().parent().host():
@@ -87,11 +87,10 @@ class PlayerWidget(QWidget):
         self.highlighted = False
 
         layout = QVBoxLayout()
-        layout.addStretch(5)
+        layout.addStretch(6)
         layout.addWidget(self.score_label, 10)
-        layout.addStretch(22)
-        layout.addWidget(self.name_label, 46)
-        layout.addStretch(2)
+        layout.addStretch(15)
+        layout.addWidget(self.name_label, 40)
         layout.addWidget(self.stats_label, 10)
         layout.addWidget(self.dummy_stats_label, 10)
         layout.addStretch(2)

--- a/jparty/utils.py
+++ b/jparty/utils.py
@@ -97,9 +97,12 @@ class CompoundObject(object):
 """add shadow to widget. Radius is proportion of widget height"""
 
 
-def add_shadow(widget, radius=0.1, offset=3):
+def add_shadow(widget, radius=None, offset=3):
     shadow = QGraphicsDropShadowEffect(widget)
-    shadow.setBlurRadius(widget.height())
+    if radius is not None:
+        shadow.setBlurRadius(radius)
+    else:
+        shadow.setBlurRadius(widget.height())
     shadow.setColor(QColor("black"))
     shadow.setOffset(offset)
     widget.setGraphicsEffect(shadow)


### PR DESCRIPTION
Show the buzz delay for each player (early or late). This is only shown on the host's screen. The value is cleared after returning to the board.

<img width="419" alt="ShareX_8WXJ6DTmly" src="https://github.com/gdsimco/JParty-with-buzzers/assets/79669334/a0eb9243-ad54-4f5a-9d52-58d2c48b6385">

<img width="360" alt="python_yOufzPybD4" src="https://github.com/gdsimco/JParty-with-buzzers/assets/79669334/fc3d4f37-9c32-42fc-b546-c5953f851057">
