### PR TITLE
Match all images

### DIFF
--- a/jparty/question_widget.py
+++ b/jparty/question_widget.py
@@ -41,6 +41,10 @@ class QuestionWidget(QWidget):
                 except requests.exceptions.RequestException as e:
                     logging.info(f"failed to load image: {question.image_link}")
             
+            logging.info(f"question has image content: {question.image_content}")
+            if question.image_content is not None and b"html" in question.image_content.lower():
+                question.image_content = None
+
             disable_images = self.config.get('showtextwithimages', DEFAULT_CONFIG['showtextwithimages']) == 'Only show text'
 
             if not disable_images and question.image_content is not None and b"Not Found" not in question.image_content:

--- a/jparty/retrieve.py
+++ b/jparty/retrieve.py
@@ -57,7 +57,7 @@ def get_image_link(text):
     # Getting the image link:
     image_link = None
     # Extract image link
-    image_link_pattern = r'\bhttps?:\/\/\S+?\.(?:png|jpe?g|bmp|PNG|JPE?G|BMP)\b'
+    image_link_pattern = r'https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)'
     image_link = re.findall(image_link_pattern, text)
     if image_link:
         image_link = image_link[0]  # Take the first link if there are multiple
@@ -67,7 +67,7 @@ def get_image_link(text):
         logging.info(f"Question: {text}, image_link: {image_link}")
 
     # Remove image link from text:
-    text_extract_pattern = r'https?:\/\/\S+?\.(?:png|jpe?g|gif|bmp|PNG|JPE?G|BMP)\b'
+    text_extract_pattern = r'https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)'
     text = re.sub(text_extract_pattern, '', text)
 
     return_values = {


### PR DESCRIPTION
Match all links regardless of extension or url parameters.

Skip showing image widget if image loaded a webpage instead.