### PR TITLE
Disable buzzes if player is already answering

### DIFF
--- a/jparty/game.py
+++ b/jparty/game.py
@@ -376,8 +376,8 @@ class Game(QObject):
         already_answered = False
         player_already_timed_out = player.istimedout
 
-        if player_already_timed_out == True:
-            logging.info(f"player is timed out")
+        # Check if player is already answering or timed out
+        if player_already_timed_out == True or self.answering_player is player:
             return
 
         if self.accepting_responses and self.answering_player is None:


### PR DESCRIPTION
Previously, players could keep buzzing after they already successfully buzzed in to answer a question. This would make the podium flash red as if the player was late to buzz.

Now, the answerer's buzzer is disabled until they are done answering so that the podium will stay white with the timer lights.