### PR TITLE
Misc fixes and improvements to video/audio questions

### DIFF
--- a/jparty/final_display.py
+++ b/jparty/final_display.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QWidget, QVBoxLayout
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QSizePolicy
 
 from jparty.scoreboard import NameLabel
 from jparty.style import MyLabel, CARDPAL
@@ -42,13 +42,14 @@ class FinalAnswerWidget(QWidget):
         self.show()
 
     def startFontSize(self):
-        return self.height() * 0.2
+        return 50
 
     def show_winner(self, winner):
         self.guess_label.setText("We have a winner!")
         self.wager_label.setText("")
-        self.winner_label = NameLabel(winner.name, self)
+        self.winner_label = NameLabel(winner.name, self, height=300)
         self.main_layout.replaceWidget(self.wager_label, self.winner_label)
+        self.setFixedHeight(400)
 
     def show_tie(self):
         self.guess_label.setText("We have a tie!")

--- a/jparty/game.py
+++ b/jparty/game.py
@@ -129,6 +129,7 @@ class Question:
     category: str
     image_link: str = None
     video_link: str = None
+    includes_audio: bool = False
     image_content: str = None
     value: int = -1
     dd: bool = False
@@ -417,7 +418,6 @@ class Game(QObject):
         # Set stats for players who buzzed early
         for player in self.players:
             if player.buzz_time is not None:
-                logging.info(f"GARRETT setting stats for early buzz")
                 time_elapsed = datetime.datetime.now() - player.buzz_time
                 self.dc.player_widget(player).update_stats(time_elapsed.total_seconds(), "early")
                 player.buzz_time = None
@@ -426,6 +426,9 @@ class Game(QObject):
             self.timer = QuestionTimer(QUESTIONTIME, self.stumped)
 
         self.timer.start()
+
+        if self.active_question.includes_audio:
+            self.host_display.question_widget.hide_video()
 
     def close_responses(self):
         self.timer.pause()

--- a/jparty/game.py
+++ b/jparty/game.py
@@ -297,6 +297,12 @@ class Game(QObject):
             self.arrowhints,
         )
         self.keystroke_manager.addEvent(
+            "ADMIN_SKIP_QUESTION",
+            Qt.Key.Key_0,
+            self.admin_skip_question,
+            self.adminhints,
+        )
+        self.keystroke_manager.addEvent(
             "ADMIN_SKIP_ROUND",
             Qt.Key.Key_F5,
             self.admin_skip_round,
@@ -378,12 +384,27 @@ class Game(QObject):
         player.waiter.close()
         self.dc.scoreboard.refresh_players()
         self.host_display.welcome_widget.check_start()
+
+        # If the host removes a player in the final jeopardy round,
+        # check if all remaining players have already wagered
+        if isinstance(self.current_round, FinalBoard):
+            self.check_if_all_wagered()
     
     def admin_skip_round(self):
         if isinstance(self.current_round, FinalBoard):
             return
         self.next_round()
         self.keystroke_manager.activate("ADMIN_SKIP_ROUND")
+    
+    def admin_skip_question(self):
+        if not self.active_question:
+            return
+        self.keystroke_manager.deactivate("BACK_TO_BOARD", "OPEN_RESPONSES")
+        self.accepting_responses = False
+        self.dc.borders.lights(False)
+        self.soliciting_player = False
+        self.answer_given()
+        self.back_to_board()
 
     def valid_game(self):
         return self.data is not None and all(b.complete() for b in self.data.rounds)
@@ -460,8 +481,9 @@ class Game(QObject):
 
     def answer_given(self):
         self.keystroke_manager.deactivate("CORRECT_ANSWER", "INCORRECT_ANSWER")
-        self.dc.player_widget(self.answering_player).stop_lights()
-        self.answering_player = None
+        if self.answering_player:
+            self.dc.player_widget(self.answering_player).stop_lights()
+            self.answering_player = None
 
     def back_to_board(self):
         logging.info("back_to_board")
@@ -471,9 +493,8 @@ class Game(QObject):
         self.active_question = None
         self.previous_answerer = []
         if all(q.complete for q in self.current_round.questions):
-            logging.info("NEXT ROUND")
-            self.keystroke_manager.activate("NEXT_ROUND")
-            self.keystroke_manager.activate("ADMIN_SHOW_STATS")
+            logging.info("Ready for next round")
+            self.keystroke_manager.activate("ADMIN_SHOW_STATS", "NEXT_ROUND")
         
         # clear stats
         for player in self.players:
@@ -504,6 +525,7 @@ class Game(QObject):
             self.set_player_in_control(None)
 
             self.dc.load_final(self.current_round.question)
+            self.dc.show_player_kick_buttons()
             self.start_final()
         else:
             # Highlight player with least money to have control
@@ -555,17 +577,21 @@ class Game(QObject):
         player.wager = amount
         self.dc.player_widget(player).set_lights(False)
         logging.info(f"{player} wagered {amount}")
+        self.check_if_all_wagered()
+
+    def answer(self, player, guess):
+        player.finalanswer = guess
+        logging.info(f"{player} guessed {guess}")
+    
+    def check_if_all_wagered(self):
         if all(p.wager is not None for p in self.players):
             self.host_display.question_widget.hint_label.setText(
                 "Press space to show clue!"
             )
             self.keystroke_manager.activate("OPEN_FINAL")
 
-    def answer(self, player, guess):
-        player.finalanswer = guess
-        logging.info(f"{player} guessed {guess}")
-
     def final_open_responses(self):
+        self.dc.hide_player_kick_buttons()
         self.dc.borders.lights(True)
         self.buzzer_controller.prompt_answers()
 
@@ -681,6 +707,7 @@ class Game(QObject):
 
     def load_question(self, q):
         self.active_question = q
+        self.keystroke_manager.activate("ADMIN_SKIP_QUESTION")
         if q.dd:
             logging.info("Daily double!")
             wo = sa.WaveObject.from_wave_file(resource_path("dd.wav"))

--- a/jparty/game.py
+++ b/jparty/game.py
@@ -256,6 +256,9 @@ class Game(QObject):
             "BACK_TO_BOARD", Qt.Key.Key_Space, self.back_to_board, self.spacehints
         )
         self.keystroke_manager.addEvent(
+            "PLAY_AUDIO", Qt.Key.Key_Space, self.play_audio, self.spacehints
+        )
+        self.keystroke_manager.addEvent(
             "OPEN_RESPONSES", Qt.Key.Key_Space, self.open_responses, self.spacehints
         )
         self.keystroke_manager.addEvent(
@@ -409,6 +412,10 @@ class Game(QObject):
 
     def valid_game(self):
         return self.data is not None and all(b.complete() for b in self.data.rounds)
+
+    def play_audio(self):
+        self.host_display.question_widget.play_video()
+        self.keystroke_manager.activate("OPEN_RESPONSES")
 
     def open_responses(self):
         self.dc.borders.lights(True)
@@ -711,15 +718,17 @@ class Game(QObject):
     def load_question(self, q):
         self.active_question = q
         self.keystroke_manager.activate("ADMIN_SKIP_QUESTION")
+        self.dc.load_question(q)
+        self.dc.remove_card(q)
         if q.dd:
             logging.info("Daily double!")
             wo = sa.WaveObject.from_wave_file(resource_path("dd.wav"))
             wo.play()
             self.soliciting_player = True
+        elif q.includes_audio:
+            self.keystroke_manager.activate("PLAY_AUDIO")
         else:
             self.keystroke_manager.activate("OPEN_RESPONSES")
-        self.dc.load_question(q)
-        self.dc.remove_card(q)
 
     def open_final(self):
         self.dc.question_widget.show_question()

--- a/jparty/main_display.py
+++ b/jparty/main_display.py
@@ -154,6 +154,12 @@ class DisplayWindow(QMainWindow):
         self.board_widget.clear()
         self.show_welcome_widgets()
         self.scoreboard.refresh_players()
+    
+    def hide_player_kick_buttons(self):
+        print("DisplayWindow: hide_player_kick_buttons (do nothing)")
+
+    def show_player_kick_buttons(self):
+        print("DisplayWindow: show_player_kick_buttons (do nothing)")
 
 
 class HostDisplayWindow(DisplayWindow):
@@ -190,4 +196,12 @@ class HostDisplayWindow(DisplayWindow):
 
     def hide_welcome_widgets(self):
         super().hide_welcome_widgets()
+        self.hide_player_kick_buttons()
+    
+    def hide_player_kick_buttons(self):
+        print("HostDisplayWindow: hide_player_kick_buttons")
         self.scoreboard.hide_close_buttons()
+
+    def show_player_kick_buttons(self):
+        print("HostDisplayWindow: show_player_kick_buttons")
+        self.scoreboard.show_close_buttons()

--- a/jparty/question_widget.py
+++ b/jparty/question_widget.py
@@ -136,6 +136,9 @@ class QuestionWidget(QWidget):
                     self.web_view.page().settings().setAttribute(
                         QWebEngineSettings.WebAttribute.LocalContentCanAccessRemoteUrls, True
                     )
+                    self.web_view.page().settings().setAttribute(
+                        QWebEngineSettings.WebAttribute.PlaybackRequiresUserGesture, False
+                    )
 
                     if audio_only or parent.host():
                         self.web_view.setFixedHeight(self.height() * 5)
@@ -158,6 +161,11 @@ class QuestionWidget(QWidget):
             exc_type, exc_obj, exc_tb = sys.exc_info()
             fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
             logging.info(f"error: {exc_type}, {fname}:{exc_tb.tb_lineno}")
+    
+    def play_video(self):
+        if hasattr(self, 'web_view'):
+            self.web_view.page().runJavaScript("startVideo();")
+            print("Starting video via JavaScript")
 
     def hide_video(self):
         if hasattr(self, 'web_view'):

--- a/jparty/question_widget.py
+++ b/jparty/question_widget.py
@@ -42,20 +42,20 @@ class QuestionWidget(QWidget):
         self.main_layout.setContentsMargins(0, 50, 0, 50)
 
         if question.video_link is not None:
-            logging.info(f"QUESTION HAS VIDEO, LOADING VIDEO: {question.video_link}")
-            self.load_video(parent, question.video_link)
+            logging.info(f"Question has video, loading video: {question.video_link}")
+            self.load_video(parent, question)
 
         elif question.image_link is not None:
-            logging.info(f"question has image: {question.image_link}")
+            logging.info(f"Question has image: {question.image_link}")
             if question.image_content is None:
                 try:
                     request = requests.get(question.image_link, timeout=1)
                     question.image_content = request.content
-                    logging.info(f"loaded image: {question.image_link}")
+                    logging.info(f"Loaded image: {question.image_link}")
                 except requests.exceptions.RequestException as e:
-                    logging.info(f"failed to load image: {question.image_link}")
+                    logging.info(f"Failed to load image: {question.image_link}")
             
-            logging.info(f"question has image content: {question.image_content}")
+            logging.info(f"Question has image content: {question.image_content}")
             if question.image_content is not None and b"html" in question.image_content.lower():
                 question.image_content = None
 
@@ -83,14 +83,14 @@ class QuestionWidget(QWidget):
         self.setPalette(CARDPAL)
         self.show()
 
-    def load_video(self, parent, video_link):
+    def load_video(self, parent, question):
         try:
             # --- Parse YouTube URL variants robustly ---
             video_url = None
             video_length = VIDEO_PLAY_TIME
             audio_only = False
 
-            u = urlparse(video_link)
+            u = urlparse(question.video_link)
             host = (u.hostname or "").lower()
             qs = parse_qs(u.query or "")
 
@@ -121,6 +121,7 @@ class QuestionWidget(QWidget):
                 a_val = (qs.get("a") or [None])[0]
                 if a_val == "1":
                     audio_only = True
+                    question.includes_audio = True
                     parts.append("a=1")
 
                 video_url = "&".join(parts)
@@ -149,8 +150,7 @@ class QuestionWidget(QWidget):
                     if not audio_only:
                         def end_video(main_layout, web_view, video_length):
                             time.sleep(video_length)
-                            main_layout.removeWidget(web_view)
-                            web_view.deleteLater()
+                            self.hide_video()
 
                         thread = threading.Thread(target=end_video, args=(self.main_layout, self.web_view, video_length,))
                         thread.start()
@@ -159,6 +159,11 @@ class QuestionWidget(QWidget):
             fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
             logging.info(f"error: {exc_type}, {fname}:{exc_tb.tb_lineno}")
 
+    def hide_video(self):
+        if hasattr(self, 'web_view'):
+            self.main_layout.removeWidget(self.web_view)
+            self.web_view.deleteLater()
+            del self.web_view
 
     def startFontSize(self):
         return self.width() * 0.05

--- a/jparty/retrieve.py
+++ b/jparty/retrieve.py
@@ -32,7 +32,7 @@ def list_to_game(s):
                 image_link = process_values['image_link']
                 video_link = process_values['video_link']
 
-                questions.append(Question(index, text, answer, cat, image_link, video_link, None, value, dd))
+                questions.append(Question(index, text, answer, cat, image_link, video_link, False, None, value, dd))
 
         boards.append(Board(categories, questions, dj=(n1 == 14)))
 
@@ -49,7 +49,7 @@ def list_to_game(s):
 
     answer = fj[3]
     category = fj[1]
-    question = Question(index, text, answer, category, image_link, video_link)
+    question = Question(index, text, answer, category, image_link, video_link, False)
     boards.append(FinalBoard(category, question))
     date = fj[5]
     comments = fj[7]
@@ -153,7 +153,7 @@ def get_JArchive_Game(game_id, wayback_url=None):
             value = MONIES[i][index[1]]
             answer = findanswer(clue)
             questions.append(
-                Question(index, text, answer, categories[index[0]], image_link, None, None, value, dd)
+                Question(index, text, answer, categories[index[0]], image_link, None, False, None, value, dd)
             )
         boards.append(Board(categories, questions, dj=(i == 1)))
 

--- a/jparty/scoreboard.py
+++ b/jparty/scoreboard.py
@@ -44,24 +44,13 @@ class NameLabel(MyLabel):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         if self.signature is not None:
-            orig_w = self.signature.width()
-            orig_h = self.signature.height()
-            bleed_h = max(4, int(self.height() * 0.03))
-
-            # Scale pixmap to fill label width, preserve aspect ratio
-            target_w = self.width() + bleed_h * 2
-            aspect_ratio = orig_w / orig_h if orig_h else 1
-            target_h = int(target_w / aspect_ratio)
-
-            scaled = self.signature.scaled(
-                target_w,
-                target_h,
-                transformMode=Qt.TransformationMode.SmoothTransformation,
+            self.setPixmap(
+                self.signature.scaled(
+                    int(self.height() * NameLabel.name_aspect_ratio),
+                    self.height(),
+                    transformMode=Qt.TransformationMode.SmoothTransformation,
+                )
             )
-
-            self.setPixmap(scaled)
-            self.setAlignment(Qt.AlignmentFlag.AlignVCenter)
-            self.setContentsMargins(-bleed_h, 0, -bleed_h, 0)
 
 
 class PlayerWidget(QWidget):

--- a/jparty/scoreboard.py
+++ b/jparty/scoreboard.py
@@ -306,3 +306,8 @@ class HostScoreBoard(ScoreBoard):
         for pw in self.player_widgets:
             pw.remove_button.setVisible(False)
             pw.remove_button.setEnabled(False)
+    
+    def show_close_buttons(self):
+        for pw in self.player_widgets:
+            pw.remove_button.setVisible(True)
+            pw.remove_button.setEnabled(True)

--- a/jparty/scoreboard.py
+++ b/jparty/scoreboard.py
@@ -24,7 +24,7 @@ from jparty.constants import DEFAULT_CONFIG
 class NameLabel(MyLabel):
     name_aspect_ratio = 1.3422
 
-    def __init__(self, name, parent):
+    def __init__(self, name, parent, height=None):
         self.signature = None
         super().__init__("", self.startNameFontSize, parent)
 
@@ -37,6 +37,8 @@ class NameLabel(MyLabel):
 
         self.setGraphicsEffect(None)
         self.setAutosizeMargins(0.05)
+        if height is not None:
+            self.setFixedHeight(height)
 
     def startNameFontSize(self):
         return self.height() * 1

--- a/jparty/video.html
+++ b/jparty/video.html
@@ -55,8 +55,12 @@
                 >
                 </iframe>
             </div>
+            <div id="click-overlay" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: pointer; z-index: 10;"></div>
         </div>
+        <script src="https://www.youtube.com/iframe_api"></script>
         <script>
+            var playerInstance;
+
             (function() {
                 // Get video id and timestamp int from url parameters
                 var urlParams = new URLSearchParams(window.location.search);
@@ -64,7 +68,7 @@
                 var timestamp = urlParams.get('t');
                 var audioOnly = urlParams.get('a');
 
-                var videoSource = "https://www.youtube.com/embed/" + videoId + "?&start=" + timestamp + "&disablekb=1";
+                var videoSource = "https://www.youtube.com/embed/" + videoId + "?&start=" + timestamp + "&disablekb=1&enablejsapi=1";
 
                 if (audioOnly) {
                     
@@ -76,6 +80,16 @@
                 var player = document.getElementById("ytplayer");
                 player.setAttribute("src", videoSource)
             })();
+
+            // Handle click on overlay to play video
+            document.getElementById('click-overlay').addEventListener('click', function() {
+                const iframe = document.getElementById("ytplayer").contentWindow;
+
+                iframe.postMessage(
+                JSON.stringify({ event: "command", func: "playVideo" }),
+                "*"
+                );
+            });
         </script>
     </body>
 </html>

--- a/jparty/video.html
+++ b/jparty/video.html
@@ -56,6 +56,7 @@
                 </iframe>
             </div>
             <div id="click-overlay" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; cursor: pointer; z-index: 10;"></div>
+            <div id="empty"/>
         </div>
         <script src="https://www.youtube.com/iframe_api"></script>
         <script>
@@ -83,13 +84,18 @@
 
             // Handle click on overlay to play video
             document.getElementById('click-overlay').addEventListener('click', function() {
+                startVideo();
+            });
+
+            function startVideo() {
+                document.getElementById("empty").focus();
                 const iframe = document.getElementById("ytplayer").contentWindow;
 
                 iframe.postMessage(
                 JSON.stringify({ event: "command", func: "playVideo" }),
                 "*"
                 );
-            });
+            }
         </script>
     </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyQt6==6.4.0
+PyQt6==6.6.0
 requests==2.31.0
 simpleaudio==1.0.4
 tornado==6.3.2
@@ -6,7 +6,7 @@ BeautifulSoup4==4.11.1
 pyinstaller==6.2.0
 qrcode==7.3.1
 pygame==2.5.2
-PyQt6-Qt6==6.4.3
-PyQt6-WebEngine-Qt6==6.6.1
+PyQt6-Qt6==6.6.0
+PyQt6-WebEngine-Qt6==6.6.0
 PyQt6-WebEngine==6.6.0
 websocket-client==1.7.0

--- a/run.py
+++ b/run.py
@@ -16,7 +16,7 @@ if not os.path.exists('config.json'):
 if __name__ == "__main__":
     print(os.getcwd())
     # Start the process and get the process object
-    process = subprocess.Popen(["python", "..\\physicalbuzzers\\physicalbuzzers.py"])
+    process = subprocess.Popen(["python3", os.path.join("..", "physicalbuzzers", "physicalbuzzers.py")])
     time.sleep(1)
     try:
         main()


### PR DESCRIPTION
Fixed various bugs and made other improvements:
- [x] Allow host to kick players out during final jeopardy wagers
- [x] Audio clues play by pressing the space bar
- [x] Add button to skip question (0 key) after the clue was already shown
- [x] Fix stretched name in the winner name label

Original PR for video/audio questions: https://github.com/gdsimco/JParty-with-buzzers/pull/41